### PR TITLE
Zero initialize local variables

### DIFF
--- a/source/opt/optimizer.cpp
+++ b/source/opt/optimizer.cpp
@@ -560,7 +560,7 @@ bool Optimizer::RegisterPassFromFlag(const std::string& flag) {
             "--switch-descriptorset requires a from:to argument.");
       return false;
     }
-    uint32_t from_set, to_set;
+    uint32_t from_set = 0, to_set = 0;
     const char* start = pass_args.data();
     const char* end = pass_args.data() + pass_args.size();
 


### PR DESCRIPTION
Certain versions of GCC warn about these variables being potentially uninitialized when used. I believe this is a false-positive, but zero-init'ing them is a safe way to fix this.